### PR TITLE
Download pre-packaged API docs from the GitHub releases

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -28,21 +28,17 @@ wget \
     "https://crystal-lang.org/reference/" || true
 
 # Fetch /api docs
-wget \
-    -e robots=off \
-    --no-verbose \
-    --recursive \
-    --reject '*.ico,*.txt,*.pdf,*.mp3,*.mp4,*.tgz,*.zip,*.flv,*.avi,*.mpeg,*.mpg,*.iso' \
-    --page-requisites \
-    --html-extension \
-    --convert-links \
-    --no-host-directories \
-    --no-parent \
-    --domains crystal-lang.org \
-    "https://crystal-lang.org/api/$CRYSTAL_VERSION/" || true
+wget https://github.com/crystal-lang/crystal/releases/download/$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-docs.tar.gz
 
-# Remove redundant api/latest folder
-rm -rf api/latest
+# Extract the docs
+tar -xvf crystal-$CRYSTAL_VERSION-docs.tar.gz
+
+# Remove the archive
+rm crystal-$CRYSTAL_VERSION-docs.tar.gz
+
+# Rename the docs folder
+mkdir api
+mv crystal-$CRYSTAL_VERSION-docs api/$CRYSTAL_VERSION
 
 # Hide the sidebar in /api docs
 echo ".sidebar { display: none !important }" >> "api/$CRYSTAL_VERSION/css/style.css"


### PR DESCRIPTION
Resolves #4

One thing to note, is that this change makes building docset out of [`master`](https://crystal-lang.org/api/master/) docs impossible (at least not without an additional logic).